### PR TITLE
Fix slur detection

### DIFF
--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -9,7 +9,7 @@ export default function containsBaseUrl(url?: string | null) {
 
 const containsSlur = (alias?: string | null) => {
   return RegExp(
-    '(fag(g|got|tard)?\b|cocks?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|\bspi(c|k)s?\b|\bchinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|\btr(a|@)nn?(y|ies?)|\b(b|re|r)tard(ed)?s?)'
+    '(fag(g|got|tard)?|cocks?sucker(s|ing)?|ni((g{2,}|q)+|[gq]{2,})[e3r]+(s|z)?|mudslime?s?|kikes?|spi(c|k)s?|chinks?|gooks?|bitch(es|ing|y)?|whor(es?|ing)|tr(a|@)nn?(y|ies?)|(b|re|r)tard(ed)?s?)'
   ).test(alias ?? '');
 };
 


### PR DESCRIPTION
Regex's word boundary doesn't work properly in JS.